### PR TITLE
Make Feedly and Hatena Compatible with SSL/TLS

### DIFF
--- a/class.sharing-sources.php
+++ b/class.sharing-sources.php
@@ -326,16 +326,28 @@ class Share_Hatena extends Sharing_Source {
 		return 'en';
 	}
 
+	private function get_resource_host() {
+		if( is_ssl() )
+			return 'https://b.hatena.ne.jp';
+
+		return 'http://b.st-hatena.com';
+	}
+
 	function get_display( $post ) {
 		$locale = $this->guess_locale_from_lang( get_locale() );
 
 		if ( $this->smart )
 			return sprintf(
-				'<div class="hatena_button"><a href="http://b.hatena.ne.jp/entry/%1$s" class="hatena-bookmark-button" data-hatena-bookmark-title="%2$s" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="%3$s" title="%4$s"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="%3$s" width="20" height="20" style="border: none;" /></a></div>',
+				'<div class="hatena_button">
+					<a href="http://b.hatena.ne.jp/entry/%1$s" class="hatena-bookmark-button" data-hatena-bookmark-title="%2$s" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="%3$s" title="%4$s">
+						<img src="%5$s" alt="%3$s" width="20" height="20" style="border: none;" />
+					</a>
+				</div>',
 				$this->get_share_url( $post->ID ),
 				esc_attr( $this->get_share_title( $post->ID ) ),
 				esc_attr( $locale ),
-				esc_attr__( 'Add this entry to Hatena Bookmark', 'jpssp' )
+				esc_attr__( 'Add this entry to Hatena Bookmark', 'jpssp' ),
+				esc_url( $this->get_resource_host() . '/images/entry-button/button-only@2x.png' )
 			);
 		else
 			return $this->get_link(
@@ -353,7 +365,7 @@ class Share_Hatena extends Sharing_Source {
 
 	function display_footer() {
 	?>
-		<script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+		<script type="text/javascript" src="<?php echo $this->get_resource_host(); ?>/js/bookmark_button.js" charset="utf-8" async="async"></script>
 	<?php
 		$this->js_dialog( $this->shortname );
 	}

--- a/count.js
+++ b/count.js
@@ -1,26 +1,26 @@
 jQuery(document).ready(function($) {
-	if ('undefined' != typeof WPCOM_sharing_counts) {
-		// Feedly
-		if(!feedly_smart ) {
-			for (var url in WPCOM_sharing_counts) {
-				get_feedly_count(url);
+	if('undefined' != typeof WPCOM_sharing_counts ) {
+		for( var url in WPCOM_sharing_counts ) {
+			// Feedly
+			if( $('#sharing-feedly-' + WPCOM_sharing_counts[ url ] ).length || ('undefined' != typeof feedly_smart && feedly_smart ) ) {
+				get_feedly_count( url );
 			}
-		} else {
-			get_feedly_count(url);
+
+			// Hatena
+			if( $('#sharing-hatena-' + WPCOM_sharing_counts[ url ] ).length )
+				get_hatena_count( url );
 		}
 
-		// Hatena
-		for (var url in WPCOM_sharing_counts) {
-			get_hatena_count(url);
-		}
 	}
 
 	function get_feedly_count(url) {
 		var request_url = feedly_api;
 
-		if(feedly_smart) {
+		if( request_url.split('//')[0] != document.location.protocol )
+			request_url.replace( request_url.split('//')[0], document.location.protocol );
+
+		if('undefined' != typeof feedly_smart && feedly_smart )
 			request_url += 'smart/';
-		}
 		
 		request_url += '?url=' + encodeURI(url) + '&callback=JPSSP_Sharing.update_feedly_count';
 
@@ -30,7 +30,8 @@ jQuery(document).ready(function($) {
 	function get_hatena_count(url) {
 		var request_url = 'http://api.b.st-hatena.com/entry.counts?url='+encodeURIComponent(url)+'&callback=JPSSP_Sharing.update_hatena_count';
 
-		get_script(request_url);
+		if('http:' == document.location.protocol )
+			get_script( request_url );
 	}
 	
 	function get_script(url) {


### PR DESCRIPTION
**Note**: When using HTTPS with non-official button style, the counter of Hatena will be not shown.
This is Hatena's issue and we'll request the provider to add HTTPS support.
